### PR TITLE
Fix Hive race condition + add Hive validation feature flag

### DIFF
--- a/src/main/java/com/vz/disposal/config/HiveConfigEntry.java
+++ b/src/main/java/com/vz/disposal/config/HiveConfigEntry.java
@@ -27,6 +27,10 @@ public class HiveConfigEntry extends ConfigEntry {
     @Getter
     @Setter
     private Boolean enableHivePartitionFilter;
+    
+    @Getter
+    @Setter
+    private boolean validationEnabled = true;
 
     @Override
     public void setDateFormat(String dateFormat) {


### PR DESCRIPTION
There are 2 main changes in this PR:
1) The un-thread safe Hive Client was being called without synchronization from multiple thread.
2) Some users did not want to run Hive validation.

## Description
1) Added synchronization around all calls to the Hive Client.
2) Added a feature flag for the Hive validation logic.

## Motivation and Context
See the description above.

## How Has This Been Tested?
This change includes some unit tests and is used by multiple users in prod.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.

